### PR TITLE
Docs: header rewrite regex has case insensitive pcre flag

### DIFF
--- a/doc/admin-guide/plugins/header_rewrite.en.rst
+++ b/doc/admin-guide/plugins/header_rewrite.en.rst
@@ -576,7 +576,8 @@ types supported:
 Operand     Description
 =========== ===================================================================
 /regex/     Matches the condition's provided value against the regular
-            expression.
+            expression. Start the regex with (?i) to flag it for a case
+            insensitive match, e.g. /(?i)regex/ will match ReGeX.
 <string     Matches if the value from the condition is lexically less than
             *string*.
 >string     Matches if the value from the condition is lexically greater than


### PR DESCRIPTION
The header rewrite plugin's regex syntax can take pcre flags. The case insensitive flag appears to be the only relevant one to headers.